### PR TITLE
Add localization support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-component-base</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-time-picker-flow</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <flow.version>1.1-SNAPSHOT</flow.version>
+        <flow.version>1.2-SNAPSHOT</flow.version>
     </properties>
 
     <repositories>
@@ -23,7 +24,9 @@
         </repository>
         <repository>
             <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <url>
+                https://oss.sonatype.org/content/repositories/vaadin-snapshots/
+            </url>
         </repository>
     </repositories>
 
@@ -77,11 +80,6 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-development-mode-detector</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.webjars.bowergithub.polymerelements</groupId>
-            <artifactId>iron-test-helpers</artifactId>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.polymerelements</groupId>
@@ -141,7 +139,7 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-component-demo-helpers</artifactId>
@@ -154,5 +152,41 @@
             <version>${flow.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-combo-box-flow</artifactId>
+            <version>1.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-data</artifactId>
+            <version>${flow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-components-testbench</artifactId>
+            <version>LATEST</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <configuration>
+                    <webApp>
+                        <resourceBases>
+                            <resourceBase>
+                                ${project.basedir}/src/main/resources/META-INF/resources
+                            </resourceBase>
+                        </resourceBases>
+                    </webApp>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -16,22 +16,24 @@
 package com.vaadin.flow.component.timepicker;
 
 import java.time.LocalTime;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
 
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.HasEnabled;
-import com.vaadin.flow.component.HasSize;
-import com.vaadin.flow.component.HasValidation;
-import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.*;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Server-side component for the <code>vaadin-time-picker</code> element.
+ * An input component for selecting time of day, based on
+ * {@code vaadin-time-picker} web component.
  *
  * @author Vaadin Ltd
  */
-public class TimePicker
-        extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
+@JavaScript("frontend://timepickerConnector.js")
+public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         implements HasSize, HasValidation, HasEnabled {
 
     private static final SerializableFunction<String, LocalTime> PARSER = s -> {
@@ -43,6 +45,27 @@ public class TimePicker
     };
 
     /**
+     * Returns a stream of all the available locales that are supported by the
+     * time picker component.
+     * <p>
+     * This is a shorthand for {@link Locale#getAvailableLocales()} where all
+     * locales without the {@link Locale#getLanguage()} have been filtered out,
+     * as the browser cannot localize the time for those.
+     *
+     * @return a stream of the available locales that are supported by the time
+     *         picker component
+     * @see #setLocale(Locale)
+     * @see Locale#getAvailableLocales()
+     * @see Locale#getLanguage()
+     */
+    public static Stream<Locale> getSupportedAvailableLocales() {
+        return Stream.of(Locale.getAvailableLocales())
+                .filter(locale -> !locale.getLanguage().isEmpty());
+    }
+
+    private Locale locale;
+
+    /**
      * Default constructor.
      */
     public TimePicker() {
@@ -51,7 +74,7 @@ public class TimePicker
 
     /**
      * Convenience constructor to create a time picker with a pre-selected time.
-     * 
+     *
      * @param time
      *            the pre-selected time in the picker
      */
@@ -61,7 +84,7 @@ public class TimePicker
 
     /**
      * Convenience constructor to create a time picker with a label.
-     * 
+     *
      * @param label
      *            the label describing the time picker
      * @see #setLabel(String)
@@ -74,7 +97,7 @@ public class TimePicker
     /**
      * Convenience constructor to create a time picker with a pre-selected time
      * and a label.
-     * 
+     *
      * @param label
      *            the label describing the time picker
      * @param time
@@ -197,7 +220,9 @@ public class TimePicker
      * <p>
      * If the step is less than 900 seconds, the dropdown is hidden.
      * </p>
-     * 
+     * // TODO this API is bad for Java and should be replaced with Duration API
+     * instead
+     *
      * @param step
      *            the step to set, unit seconds
      */
@@ -208,12 +233,13 @@ public class TimePicker
 
     /**
      * Gets the step of the time picker.
-     * 
+     *
      * <p>
      * This property is not synchronized automatically from the client side, so
      * the returned value may not be the same as in client side.
-     * 
-     * @return the {@code step} property from the picker, unit seconds
+     *
+     * @return the {@code step} property from the picker, unit seconds // TODO
+     *         kill with fire, see setter
      */
     public double getStep() {
         return super.getStepDouble();
@@ -223,5 +249,78 @@ public class TimePicker
     public Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<TimePicker>> listener) {
         return super.addInvalidChangeListener(listener);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        if (getLocale() == null) {
+            setLocale(attachEvent.getUI().getLocale());
+        }
+        initConnector();
+    }
+
+    private void initConnector() {
+        runBeforeClientResponse(ui -> ui.getPage().executeJavaScript(
+                "window.Vaadin.Flow.timepickerConnector.initLazy($0)",
+                getElement()));
+    }
+
+    /**
+     * Set the Locale for the Time Picker. The displayed time will be formatted
+     * by the browser using the given locale.
+     * <p>
+     * The default locale is fetched from the {@link UI#getLocale()} when the
+     * component is attached to an UI.
+     * <p>
+     * The time formatting is done in the browser using the <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString">Date.toLocaleTimeString()</a>
+     * function.
+     * <p>
+     * If for some reason the browser doesn't support the given locale, the
+     * en-US locale is used.
+     * <p>
+     * <em>NOTE: only the language + country/region codes are used</em>. This
+     * means that the script and variant information is not used and supported.
+     * <em>NOTE: timezone related data is not supported.</em>
+     *
+     * @param locale
+     *            the locale set to the time picker, cannot be [@code null}
+     */
+    public void setLocale(Locale locale) {
+        Objects.requireNonNull(locale, "Locale must not be null.");
+        if (locale.getLanguage().isEmpty()) {
+            throw new UnsupportedOperationException("Given Locale " + locale.getDisplayName()
+                    + " is not supported by time picker because it is missing the language information.");
+        }
+
+        this.locale = locale;
+        // we could support script & variant, but that requires more work on
+        // client side to detect the different
+        // number characters for other scripts (current only Arabic there)
+        StringBuilder bcp47LanguageTag = new StringBuilder(
+                locale.getLanguage());
+        if (!locale.getCountry().isEmpty()) {
+            bcp47LanguageTag.append("-").append(locale.getCountry());
+        }
+        runBeforeClientResponse(ui -> getElement().callFunction(
+                "$connector.setLocale", bcp47LanguageTag.toString()));
+    }
+
+    /**
+     * Gets the Locale for this date picker.
+     * <p>
+     * By default, the locale is empty until the component is attached to an UI,
+     *
+     * @return the locale used for this picker
+     */
+    @Override
+    public Locale getLocale() {
+        return locale;
+    }
+
+    private void runBeforeClientResponse(SerializableConsumer<UI> command) {
+        getElement().getNode().runWhenAttached(ui -> ui
+                .beforeClientResponse(this, context -> command.accept(ui)));
     }
 }

--- a/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -239,6 +239,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     }
 
     private void initConnector() {
+        // can't run this with getElement().executeJavaScript(...) since then
+        // setLocale might be called before this causing client side error
         runBeforeClientResponse(ui -> ui.getPage().executeJavaScript(
                 "window.Vaadin.Flow.timepickerConnector.initLazy($0)",
                 getElement()));
@@ -248,8 +250,9 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      * Set the Locale for the Time Picker. The displayed time will be formatted
      * by the browser using the given locale.
      * <p>
-     * The default locale is fetched from the {@link UI#getLocale()} when the
-     * component is attached to an UI.
+     * By default, the locale is {@code null} until the component is attached to
+     * an UI, and then locale is set to {@link UI#getLocale()}, unless a locale
+     * has been explicitly set before that.
      * <p>
      * The time formatting is done in the browser using the <a href=
      * "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString">Date.toLocaleTimeString()</a>
@@ -289,7 +292,9 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     /**
      * Gets the Locale for this date picker.
      * <p>
-     * By default, the locale is empty until the component is attached to an UI,
+     * By default, the locale is {@code null} until the component is attached to
+     * an UI, and then locale is set to {@link UI#getLocale()}, unless
+     * {@link #setLocale(Locale)} has been explicitly called before that.
      *
      * @return the locale used for this picker
      */

--- a/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -44,25 +44,6 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         return d == null ? "" : d.toString();
     };
 
-    /**
-     * Returns a stream of all the available locales that are supported by the
-     * time picker component.
-     * <p>
-     * This is a shorthand for {@link Locale#getAvailableLocales()} where all
-     * locales without the {@link Locale#getLanguage()} have been filtered out,
-     * as the browser cannot localize the time for those.
-     *
-     * @return a stream of the available locales that are supported by the time
-     *         picker component
-     * @see #setLocale(Locale)
-     * @see Locale#getAvailableLocales()
-     * @see Locale#getLanguage()
-     */
-    public static Stream<Locale> getSupportedAvailableLocales() {
-        return Stream.of(Locale.getAvailableLocales())
-                .filter(locale -> !locale.getLanguage().isEmpty());
-    }
-
     private Locale locale;
 
     /**
@@ -220,8 +201,6 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      * <p>
      * If the step is less than 900 seconds, the dropdown is hidden.
      * </p>
-     * // TODO this API is bad for Java and should be replaced with Duration API
-     * instead
      *
      * @param step
      *            the step to set, unit seconds
@@ -238,8 +217,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      * This property is not synchronized automatically from the client side, so
      * the returned value may not be the same as in client side.
      *
-     * @return the {@code step} property from the picker, unit seconds // TODO
-     *         kill with fire, see setter
+     * @return the {@code step} property from the picker, unit seconds
      */
     public double getStep() {
         return super.getStepDouble();
@@ -290,7 +268,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     public void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale must not be null.");
         if (locale.getLanguage().isEmpty()) {
-            throw new UnsupportedOperationException("Given Locale " + locale.getDisplayName()
+            throw new UnsupportedOperationException("Given Locale "
+                    + locale.getDisplayName()
                     + " is not supported by time picker because it is missing the language information.");
         }
 
@@ -322,5 +301,24 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, context -> command.accept(ui)));
+    }
+
+    /**
+     * Returns a stream of all the available locales that are supported by the
+     * time picker component.
+     * <p>
+     * This is a shorthand for {@link Locale#getAvailableLocales()} where all
+     * locales without the {@link Locale#getLanguage()} have been filtered out,
+     * as the browser cannot localize the time for those.
+     *
+     * @return a stream of the available locales that are supported by the time
+     *         picker component
+     * @see #setLocale(Locale)
+     * @see Locale#getAvailableLocales()
+     * @see Locale#getLanguage()
+     */
+    public static Stream<Locale> getSupportedAvailableLocales() {
+        return Stream.of(Locale.getAvailableLocales())
+                .filter(locale -> !locale.getLanguage().isEmpty());
     }
 }

--- a/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -1,0 +1,175 @@
+window.Vaadin.Flow.timepickerConnector = {
+    initLazy: function (timepicker) {
+        // Check whether the connector was already initialized for the timepicker
+        if (timepicker.$connector) {
+            return;
+        }
+
+        timepicker.$connector = {};
+
+        const getAmPmString = function (locale, testTime) {
+            const testTimeString = testTime.toLocaleTimeString(locale);
+            // AM/PM string is anything from one letter in arabic to standard two letters,
+            // to having space in between, dots ...
+            // cannot disqualify whitespace since some locales use a. m. / p. m.
+            // TODO when more scripts support is added (than Arabic), need to exclude those numbers too
+            const endWithAmPmRegex = /[^\d\u0660-\u0669]+$/g;
+            let amPmString = testTimeString.match(endWithAmPmRegex);
+            if (amPmString) {
+                amPmString = amPmString[0].trim();
+            } else {
+                // eg. chinese (and some else too) starts with am/pm
+                amPmString = testTimeString.match(/^[^\d\u0660-\u0669]+/g);
+                amPmString ? amPmString[0].trim() : amPmString;
+            }
+            return amPmString;
+        };
+        const testPmTime = new Date('August 19, 1975 23:15:30');
+
+        const getPmString = function (locale) {
+            return getAmPmString(locale, testPmTime);
+        };
+
+        const getAmString = function (locale) {
+            const testTime = new Date('August 19, 1975 05:15:30');
+            return getAmPmString(locale, testTime);
+        };
+
+        // map from unicode arabic characters to numbers
+        const arabicDigitMap = {
+            '\\u0660': '0',
+            '\\u0661': '1',
+            '\\u0662': '2',
+            '\\u0663': '3',
+            '\\u0664': '4',
+            '\\u0665': '5',
+            '\\u0666': '6',
+            '\\u0667': '7',
+            '\\u0668': '8',
+            '\\u0669': '9'
+        };
+
+        // parses eastern arabic number characters to arabic numbers (0-9)
+        const parseAnyCharsToInt = function (arabicDigit) {
+            return parseInt(arabicDigit.replace(/[\u0660-\u0669]/g, function (char) {
+                const unicode = '\\u0' + char.charCodeAt(0).toString(16);
+                return arabicDigitMap[unicode];
+            }));
+        };
+
+        timepicker.$connector.setLocale = function (locale) {
+            // capture previous value if any
+            let previousValueObject;
+            if (timepicker.value && timepicker.value !== '') {
+                previousValueObject = timepicker.i18n.parseTime(timepicker.value);
+            }
+
+            try {
+                // Check whether the locale is supported by the browser or not
+                console.log(locale.toUpperCase() + ": " + testPmTime.toLocaleTimeString(locale));
+            } catch (e) {
+                locale = "en-US";
+                // FIXME should do a callback for server to throw an exception ?
+                console.error("vaadin-time-picker: The locale " + locale + " is not supported, falling back to default locale setting(en-US).");
+            }
+
+            // 1. 24 or 12 hour clock, if latter then what are the am/pm strings ?
+            const pmString = getPmString(locale);
+            const amString = getAmString(locale);
+
+            // 2. What is the separator ?
+            let localeTimeString = testPmTime.toLocaleTimeString(locale);
+            // since the next regex picks first non-number-whitespace, need to discard possible am/pm from beginning (eg. chinese locale)
+            if (pmString && localeTimeString.startsWith(pmString)) {
+                localeTimeString = localeTimeString.replace(pmString, '');
+            }
+            const separator = localeTimeString.match(/[^\u0660-\u0669\s\d]/);
+            //console.info(locale.toUpperCase() + " AM/PM: " + amString + "/" + pmString + ", separator " + separator);
+
+            // 3. regexp that allows to find the numberd and continuing searching after it
+            // TODO milliseconds have their own separator, and could be handled separately
+            const numbersRegExp = new RegExp('([\\d\\u0660-\\u0669]){1,2}(?:' + separator + ')?', 'g');
+
+            const includeSeconds = function () {
+                return timepicker.step && timepicker.step < 60;
+            };
+
+            const includeMilliSeconds = function () {
+                return timepicker.step && timepicker.step < 1;
+            };
+
+            // the web component expects the correct granularity used for the time string,
+            // thus need to format the time object in correct granularity by passing the format options
+            let cachedStep = timepicker.step;
+            let cachedOptions;
+            const getTimeFormatOptions = function () {
+                if (!cachedOptions || cachedStep && timepicker.step && cachedStep !== timepicker.step) {
+                    cachedOptions = {
+                        hour: "numeric",
+                        minute: "numeric",
+                        second: includeSeconds() ? "numeric" : undefined,
+                        milliseconds: includeMilliSeconds() ? "numeric" : undefined
+                    };
+                }
+                return cachedOptions;
+            };
+
+            timepicker.i18n = {
+                formatTime: function (timeObject) {
+                    if (timeObject) {
+                        let time = new Date();
+                        time.setHours(timeObject.hours);
+                        time.setMinutes(timeObject.minutes);
+                        time.setSeconds(timeObject.seconds !== undefined ? timeObject.seconds : 0);
+                        time.setMilliseconds(timeObject.milliseconds !== undefined ? timeObject.milliseconds : 0);
+                        return time.toLocaleTimeString(locale, getTimeFormatOptions());
+                    }
+                },
+                parseTime: function (timeString) {
+                    if (timeString) {
+                        const pm = timeString.search(pmString);
+                        const am = timeString.search(amString);
+                        const numbersOnlyTimeString = timeString.replace(amString, '').replace(pmString, '').trim();
+                        let hours = numbersRegExp.exec(numbersOnlyTimeString);
+                        if (hours) {
+                            hours = parseAnyCharsToInt(hours[0].replace(separator, ''));
+                            // handle 12 am -> 0
+                            // do not do anything if am & pm are not used or if those are the same,
+                            // as with locale bg-BG there is always  ч. at the end of the time
+                            if (pm !== am) {
+                                if (hours === 12 && am !== -1) {
+                                    hours = 0;
+                                } else {
+                                    hours += (pm !== -1 && hours !== 12 ? 12 : 0)
+                                }
+                            }
+                            const minutes = numbersRegExp.exec(numbersOnlyTimeString);
+                            const seconds = minutes && numbersRegExp.exec(numbersOnlyTimeString);
+                            // TODO milliseconds has its own separator
+                            const milliseconds = seconds && numbersRegExp.exec(numbersOnlyTimeString);
+                            // hours is a number at this point, others are either arrays or null
+                            // the string in [0] from the arrays includes the separator too
+                            return hours !== undefined && {
+                                hours: hours,
+                                minutes: minutes ? parseAnyCharsToInt(minutes[0].replace(separator, '')) : 0,
+                                seconds: seconds ? parseAnyCharsToInt(seconds[0].replace(separator, '')) : 0,
+                                milliseconds: milliseconds ? parseAnyCharsToInt(milliseconds[0].replace(separator, '')) : 0
+                            };
+                        }
+                        // when nothing is returned, the component shows the invalid state for the input
+                    }
+                }
+            };
+
+            if (previousValueObject) {
+                const newValue = timepicker.i18n.formatTime(previousValueObject);
+                // FIXME works but uses private API, needs fixes in web component
+                if (timepicker.__inputElement.value !== newValue) {
+                    timepicker.__inputElement.value = newValue;
+                    timepicker.__dropdownElement.value = newValue;
+                    timepicker.__onInputChange();
+                }
+            }
+        }
+    }
+};

--- a/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -9,30 +9,30 @@ window.Vaadin.Flow.timepickerConnector = {
 
         const getAmPmString = function (locale, testTime) {
             const testTimeString = testTime.toLocaleTimeString(locale);
-            // AM/PM string is anything from one letter in arabic to standard two letters,
+            // AM/PM string is anything from one letter in eastern arabic to standard two letters,
             // to having space in between, dots ...
             // cannot disqualify whitespace since some locales use a. m. / p. m.
             // TODO when more scripts support is added (than Arabic), need to exclude those numbers too
             const endWithAmPmRegex = /[^\d\u0660-\u0669]+$/g;
             let amPmString = testTimeString.match(endWithAmPmRegex);
-            if (amPmString) {
-                amPmString = amPmString[0].trim();
-            } else {
+            if (!amPmString) {
                 // eg. chinese (and some else too) starts with am/pm
                 amPmString = testTimeString.match(/^[^\d\u0660-\u0669]+/g);
-                amPmString ? amPmString[0].trim() : amPmString;
+            }
+            if (amPmString) {
+                amPmString = amPmString[0].trim();
             }
             return amPmString;
         };
         const testPmTime = new Date('August 19, 1975 23:15:30');
+        const testAmTime = new Date('August 19, 1975 05:15:30');
 
         const getPmString = function (locale) {
             return getAmPmString(locale, testPmTime);
-        };
 
+        };
         const getAmString = function (locale) {
-            const testTime = new Date('August 19, 1975 05:15:30');
-            return getAmPmString(locale, testTime);
+            return getAmPmString(locale, testAmTime);
         };
 
         // map from unicode arabic characters to numbers
@@ -79,7 +79,7 @@ window.Vaadin.Flow.timepickerConnector = {
 
             // 2. What is the separator ?
             let localeTimeString = testPmTime.toLocaleTimeString(locale);
-            // since the next regex picks first non-number-whitespace, need to discard possible am/pm from beginning (eg. chinese locale)
+            // since the next regex picks first non-number-whitespace, need to discard possible PM from beginning (eg. chinese locale)
             if (pmString && localeTimeString.startsWith(pmString)) {
                 localeTimeString = localeTimeString.replace(pmString, '');
             }

--- a/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
+++ b/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerIT.java
@@ -44,8 +44,7 @@ public class TimePickerIT extends ComponentDemoTest {
 
         executeScript("arguments[0].value = '10:08'", picker);
 
-        waitUntil(driver -> message.getText()
-                .contains("Hour: 10\nMinute: 8"));
+        waitUntil(driver -> message.getText().contains("Hour: 10\nMinute: 8"));
 
         executeScript("arguments[0].value = ''", picker);
 
@@ -70,7 +69,7 @@ public class TimePickerIT extends ComponentDemoTest {
                 .id("step-setting-picker");
         openPickerDropDown(picker);
         waitForElementPresent(By.tagName("vaadin-combo-box-overlay"));
-        Assert.assertEquals("Item in the dropdown is not correct", "01:00",
+        Assert.assertEquals("Item in the dropdown is not correct", "1:00 AM",
                 findItemText(1));
         closePickerDropDown(picker);
         executeScript("arguments[0].value = '12:31'", picker);
@@ -86,17 +85,16 @@ public class TimePickerIT extends ComponentDemoTest {
         clickButtonAndAssertText(900.0, "12:31", picker);
         openPickerDropDown(picker);
         waitForElementPresent(By.tagName("vaadin-combo-box-overlay"));
-        Assert.assertEquals("Item in the dropdown is not correct", "00:15",
+        Assert.assertEquals("Item in the dropdown is not correct", "12:15 AM",
                 findItemText(1));
         closePickerDropDown(picker);
     }
 
     private String findItemText(int index) {
-        return $("vaadin-combo-box-overlay").first()
-                .$(TestBenchElement.class).id("content")
-                .$(TestBenchElement.class).id("selector")
-                .$("vaadin-combo-box-item").get(index)
-                .$(TestBenchElement.class).id("content").getText();
+        return $("vaadin-combo-box-overlay").first().$(TestBenchElement.class)
+                .id("content").$(TestBenchElement.class).id("selector")
+                .$("vaadin-combo-box-item").get(index).$(TestBenchElement.class)
+                .id("content").getText();
     }
 
     private void openPickerDropDown(TestBenchElement picker) {

--- a/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -1,0 +1,248 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+@TestPath("time-picker-localization")
+public class TimePickerLocalizationIT extends AbstractComponentIT {
+
+    public static final int MINIMUM_NUMBER_OF_LOCALES_TO_TEST = 159;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.tagName("vaadin-time-picker"));
+    }
+
+    @Override
+    protected int getDeploymentPort() {
+        return super.getDeploymentPort();
+    }
+
+    @Test
+    public void testAllAvailableLocalesWhenValueChangedFromDropDown_stepOneHourAndFormatHourMinute_pickerValuesMatchesBrowserFormatted() {
+        // select locale based on locale string
+        // test via drop down 00:00 (0) 6:00 (7) 12:00 (13) 18:00 (19) 23:00(24)
+        // time picker stores values as a string that is not the same as the
+        // shown value in the input
+        // this test validates both, value and visible string format in input
+        // (the drop down values are not validated, those are anyway the same as
+        // what ends up in the input element)
+
+        // the values to test - the component stores value using 24-clock
+        String[] values = new String[] { "00:00", "06:00", "12:00", "18:00",
+                "23:00" };
+        // index of the value elements in the drop down
+        List<Integer> valueIndices = Arrays.asList(0, 6, 12, 18, 23);
+
+        runLocalisationTestPattern(values, valueIndices);
+    }
+
+    @Test
+    public void testAllAvailableLocalesWhenValueChangedFromDropDown_step30Minutes_pickerValuesMatchesBrowserFormatted() {
+        // same stuff as the previous test, but instead use a different step
+
+        selectStep("1800.0"); // could test with eg. 15 minutes, but after
+        // scrolling down, the iron-list ditches the first items and the indexes
+        // are f'ckd, thus after
+        // certain point it is too fragile to test based on indexes, index 0
+        // might not be the top most item
+
+        // cannot test further than 13:00, otherwise the item at index 0 will be
+        // 00:30 instead of 00:00 ...
+        runLocalisationTestPattern(
+                new String[] { "00:00", "00:30", "01:00", "06:00", "06:30" },
+                Arrays.asList(0, 1, 2, 12, 13));
+    }
+
+    @Test
+    public void testInitialValue_nonDefaultLocale_initialValueLocalizedCorrectly() {
+        runInitialLoadValueTestPattern("en-US", "15:00");
+        runInitialLoadValueTestPattern("en-CA", "03:00");
+        runInitialLoadValueTestPattern("fi-FI", "15:00");
+        runInitialLoadValueTestPattern("no-NO", "00:00");
+        runInitialLoadValueTestPattern("ar-SY", "15:00");
+        runInitialLoadValueTestPattern("ar-JO", "11:00");
+        runInitialLoadValueTestPattern("zh-TW", "15:00");
+        runInitialLoadValueTestPattern("ko-KR", "23:00");
+        runInitialLoadValueTestPattern("es-PA", "15:00");
+    }
+
+    private void runInitialLoadValueTestPattern(String locale, String time) {
+        String url = getTestURL() + "/" + locale + "-" + time;
+        this.getDriver().get(url);
+        waitForElementPresent(By.tagName("vaadin-time-picker"));
+
+        String error = verifyValueProperty(time);
+        Assert.assertNull(
+                "Wrong value on page load for locale " + locale + ": " + error,
+                error);
+        error = verifyFormat();
+        Assert.assertNull(
+                "Wrong format on page load for locale " + locale + ": " + error,
+                error);
+
+    }
+
+    // TODO could add another test that verifies formats the time values to
+    // labels and compares the values in the drop down to those
+
+    private void runLocalisationTestPattern(String[] values,
+            List<Integer> valueIndices) {
+        Locale locale = null;
+
+        int numberOfErrors = 0;
+        Logger logger = Logger.getLogger(getClass().getName());
+        for (Iterator<Locale> localeIterator = TimePicker
+                .getSupportedAvailableLocales()
+                .iterator(); ((Iterator) localeIterator).hasNext();) {
+            List<String> errors = new ArrayList<>();
+            Locale oldLocale = locale;
+            locale = localeIterator.next();
+            selectLocale(locale);
+            String error;
+
+            // verify that any previously selected value was updated correctly
+            // in the input element
+            // (the value property object stays the same even when locale
+            // changed)
+            if (oldLocale != null) {
+                error = verifyFormat();
+                if (error != null) {
+                    errors.add(prettyPrint(locale)
+                            + " after locale change, input format error: "
+                            + error);
+                    error = null;
+                }
+            }
+            for (Integer value : valueIndices) {
+                selectItem(value);
+                error = verifyValueProperty(
+                        values[valueIndices.indexOf(value)]);
+                if (error != null) {
+                    errors.add(prettyPrint(locale) + " value property error: "
+                            + error);
+                    error = null;
+                }
+                error = verifyFormat();
+                if (error != null) {
+                    errors.add(prettyPrint(locale) + " input format error: "
+                            + error);
+                    error = null;
+                }
+            }
+            if (!errors.isEmpty()) {
+                // log errors early so test run can be interrupted early
+                logger.severe(
+                        errors.stream().collect(Collectors.joining("\n")));
+                numberOfErrors++;
+            } else {
+                logger.info(
+                        "Locale " + locale.getDisplayName() + " validated.");
+            }
+        }
+        long numberOfTestedLocales = TimePicker.getSupportedAvailableLocales()
+                .count();
+        logger.info("Tested time picker localization with "
+                + numberOfTestedLocales + " locales");
+        if (numberOfErrors > 0) {
+            org.junit.Assert.fail("Localization Errors: " + numberOfErrors);
+        }
+        Assert.assertTrue("Not enough locales tested",
+                MINIMUM_NUMBER_OF_LOCALES_TO_TEST <= numberOfTestedLocales);
+    }
+
+    private String verifyValueProperty(String value) {
+        String timePickerValue = getTimePickerValue();
+        if (value.equals(timePickerValue)) {
+            return null;
+        } else {
+            return "expected: " + value + " actual: " + timePickerValue;
+        }
+    }
+
+    private String verifyFormat() {
+        String timePickerInputValue = getTimePickerInputValue();
+        String formattedTextValue = getLabelValue();
+        if (formattedTextValue.equals(timePickerInputValue)) {
+            return null;
+        } else {
+            return "expected: " + formattedTextValue + " actual: "
+                    + timePickerInputValue;
+        }
+    }
+
+    private void selectItem(Integer index) {
+        selectComboBoxItemByIndex(getTimePickerComboBox(), index);
+    }
+
+    private void selectLocale(Locale locale) {
+        TestBenchElement comboBox = $("vaadin-combo-box").id("locale-picker");
+        executeScript("arguments[0]['$'].clearButton.click()", comboBox);
+        comboBox.sendKeys(TimePickerLocalizationView.getLocaleString(locale)
+                + Keys.RETURN);
+    }
+
+    private void selectStep(String step) {
+        TestBenchElement comboBox = $("vaadin-combo-box").id("step-picker");
+        executeScript("arguments[0]['$'].clearButton.click()", comboBox);
+        comboBox.sendKeys(step + Keys.RETURN);
+    }
+
+    private void selectComboBoxItemByIndex(TestBenchElement comboBox,
+            int index) {
+        executeScript("arguments[0].open()", comboBox);
+
+        scrollToItem(comboBox, index);
+
+        TestBenchElement item = $("vaadin-combo-box-overlay").first()
+                .$(TestBenchElement.class).id("content")
+                .$(TestBenchElement.class).id("selector")
+                .$("vaadin-combo-box-item").get(index);
+        item.click();
+    }
+
+    private void scrollToItem(TestBenchElement comboBox, int index) {
+        executeScript("arguments[0].$.overlay._scrollIntoView(arguments[1])",
+                comboBox, index);
+    }
+
+    private TestBenchElement getTimePickerComboBox() {
+        TestBenchElement picker = getTimePickerElement();
+        return picker.$("vaadin-combo-box-light").get(0);
+    }
+
+    private String getLabelValue() {
+        return $("div").id("formatted-time").getText();
+    }
+
+    private String getTimePickerValue() {
+        return getTimePickerElement().getPropertyString("value");
+    }
+
+    private String getTimePickerInputValue() {
+        return getTimePickerElement().$("vaadin-combo-box-light").first()
+                .$("vaadin-time-picker-text-field").first()
+                .getPropertyString("value");
+    }
+
+    private TestBenchElement getTimePickerElement() {
+        return $("vaadin-time-picker").first();
+    }
+
+    private static String prettyPrint(Locale locale) {
+        return locale.getDisplayName() + "["
+                + TimePickerLocalizationView.getLocaleString(locale) + "]";
+    }
+}

--- a/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationView.java
+++ b/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationView.java
@@ -1,0 +1,84 @@
+package com.vaadin.flow.component.timepicker.tests;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.component.timepicker.demo.TimePickerView;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+@Route("time-picker-localization")
+public class TimePickerLocalizationView extends Div
+        implements HasUrlParameter<String> {
+
+    private final TimePicker timePicker;
+    private final TimePickerView.LocalTimeTextBlock browserFormattedTime;
+
+    public TimePickerLocalizationView() {
+        Stream<Locale> supportedAvailableLocales = TimePicker
+                .getSupportedAvailableLocales();
+        ComboBox<Locale> localesCB = new ComboBox<>();
+        localesCB.setItemLabelGenerator(
+                TimePickerLocalizationView::getLocaleString);
+        localesCB.setWidth("300px");
+        localesCB.setItems(supportedAvailableLocales);
+        localesCB.setId("locale-picker");
+
+        ComboBox<Double> stepSelector = new ComboBox<>();
+        stepSelector.setItems(0.5, 10.0, 60.0, 900.0, 1800.0, 3600.0);
+        stepSelector.setId("step-picker");
+        stepSelector.setValue(3600.0); // default is null but it is really an
+                                       // hour
+
+        timePicker = new TimePicker();
+
+        browserFormattedTime = new TimePickerView.LocalTimeTextBlock();
+        browserFormattedTime.setId("formatted-time");
+
+        localesCB.addValueChangeListener(event -> {
+            if (event.getValue() == null) {
+                return;
+            }
+            timePicker.setLocale(event.getValue());
+            browserFormattedTime.setLocale(event.getValue());
+        });
+
+        stepSelector.addValueChangeListener(event -> {
+            if (event.getValue() != null)
+                timePicker.setStep(event.getValue().doubleValue());
+        });
+
+        timePicker.addValueChangeListener(
+                event -> browserFormattedTime.setLocalTime(event.getValue()));
+
+        add(localesCB, stepSelector, timePicker, browserFormattedTime);
+        localesCB.setValue(UI.getCurrent().getLocale());
+    }
+
+    @Override
+    public void setParameter(BeforeEvent beforeEvent,
+            @OptionalParameter String initialValue) {
+        if (initialValue != null) {
+            // eg. fi-FI-10-30
+            String[] split = initialValue.split("\\W");
+            Locale locale = new Locale(split[0], split[1]);
+
+            timePicker.setLocale(locale);
+            browserFormattedTime.setLocale(locale);
+            timePicker.setValue(LocalTime.of(Integer.parseInt(split[2]),
+                    Integer.parseInt(split[3])));
+        }
+    }
+
+    static String getLocaleString(Locale locale) {
+        return locale.getLanguage() + "-" + locale.getCountry();
+    }
+}


### PR DESCRIPTION
Support 159 locales from Java with Arabic numerals and Eastern Arabic
numerals. Could add support for numerals in other scripts later on.

Next steps are to improve the step API for Java side, and add more tests
for entering time with keyboard input.

Fixes #2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/6)
<!-- Reviewable:end -->
