### PR TITLE
removed obsolete version for the jetty plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
                 <configuration>
                     <webApp>
                         <resourceBases>


### PR DESCRIPTION
declared in parent project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/12)
<!-- Reviewable:end -->
