### PR TITLE
fix for LocalTime.now()

### DIFF
--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.timepicker;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.time.LocalTime;
 import java.util.Locale;
 import java.util.Objects;
@@ -119,6 +120,17 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         super.setLabel(label);
     }
 
+    /**
+     * This is needed because the LocalTime format is not the same depending on the platform.
+     * 
+     */
+    
+    @Override
+    public void setValue(LocalTime value) {
+    	LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
+    	super.setValue(truncated_value);
+    }
+    
     /**
      * Gets the label of the time picker.
      *

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -127,8 +127,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     
     @Override
     public void setValue(LocalTime value) {
-    	LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
-    	super.setValue(truncated_value);
+    	LocalTime truncatedValue = value.truncatedTo(ChronoUnit.MILLIS);
+    	super.setValue(truncatedValue);
     }
     
     /**

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -120,11 +120,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         super.setLabel(label);
     }
 
-    /**
-     * This is needed because the LocalTime format is not the same depending on the platform.
-     * 
-     */
-    
+    //This is needed because the LocalTime format is not the same depending on the platform.
     @Override
     public void setValue(LocalTime value) {
     	LocalTime truncatedValue = value.truncatedTo(ChronoUnit.MILLIS);


### PR DESCRIPTION
This is just a small fix for https://github.com/vaadin/vaadin-time-picker-flow/issues/15
Given how straightforward it is, I don't think it needs a test, but let me know what you think.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/28)
<!-- Reviewable:end -->
