### PR TITLE
Cherry-pick: fix for LocalTime.now() (#28)

### DIFF
--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.timepicker;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.time.LocalTime;
 import java.util.Locale;
 import java.util.Objects;
@@ -119,6 +120,13 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         super.setLabel(label);
     }
 
+    //This is needed because the LocalTime format is not the same depending on the platform.
+    @Override
+    public void setValue(LocalTime value) {
+    	LocalTime truncatedValue = value.truncatedTo(ChronoUnit.MILLIS);
+    	super.setValue(truncatedValue);
+    }
+    
     /**
      * Gets the label of the time picker.
      *


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/29)
<!-- Reviewable:end -->
