### PR TITLE
Allow null values for setValue() in TimePicker

### DIFF
--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.timepicker;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.time.LocalTime;
 import java.util.Locale;
 import java.util.Objects;
@@ -119,6 +120,17 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         super.setLabel(label);
     }
 
+    /**
+     * This is needed because the LocalTime format is not the same depending on the platform.
+     * 
+     */
+    
+    @Override
+    public void setValue(LocalTime value) {
+    	LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
+    	super.setValue(truncated_value);
+    }
+    
     /**
      * Gets the label of the time picker.
      *

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -127,8 +127,12 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     
     @Override
     public void setValue(LocalTime value) {
-    	LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
-    	super.setValue(truncated_value);
+        if (value == null) {
+            super.setValue(null)    
+        } else {
+            LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
+            super.setValue(truncated_value);
+        }
     }
     
     /**

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -123,17 +123,12 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     //This is needed because the LocalTime format is not the same depending on the platform.
     @Override
     public void setValue(LocalTime value) {
-<<<<<<< HEAD
         if (value == null) {
             super.setValue(null)    
         } else {
             LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
             super.setValue(truncated_value);
         }
-=======
-    	LocalTime truncatedValue = value.truncatedTo(ChronoUnit.MILLIS);
-    	super.setValue(truncatedValue);
->>>>>>> d89a43eb3ce104ca90e74d69403cc43b4f5de514
     }
     
     /**

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -124,7 +124,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     @Override
     public void setValue(LocalTime value) {
         if (value == null) {
-            super.setValue(null)    
+            super.setValue(null);
         } else {
             LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
             super.setValue(truncated_value);

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -127,8 +127,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     
     @Override
     public void setValue(LocalTime value) {
-    	LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
-    	super.setValue(truncated_value);
+    	LocalTime truncatedValue = value.truncatedTo(ChronoUnit.MILLIS);
+    	super.setValue(truncatedValue);
     }
     
     /**

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -120,11 +120,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         super.setLabel(label);
     }
 
-    /**
-     * This is needed because the LocalTime format is not the same depending on the platform.
-     * 
-     */
-    
+    //This is needed because the LocalTime format is not the same depending on the platform.
     @Override
     public void setValue(LocalTime value) {
     	LocalTime truncatedValue = value.truncatedTo(ChronoUnit.MILLIS);


### PR DESCRIPTION
This came up :

This commit breaks the feature of setting NULL values in timepicker:

``` 
public void setValue(LocalTime value) {
    	LocalTime truncated_value = value.truncatedTo(ChronoUnit.MILLIS);
    	super.setValue(truncated_value);
}
```

[https://github.com/vaadin/vaadin-time-picker-flow/commit/e1b3a2fc6cd5e1a213a60969e43bf90f3047383f#diff-242f4700b1a3ce7b94bf2092fb36ad88](url)

_Originally posted by @ThijsMaenhout in https://github.com/vaadin/vaadin-time-picker-flow/pull/28#issuecomment-478868036_

This is a fix for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/30)
<!-- Reviewable:end -->
