### PR TITLE
Fix NPE on selecting empty Locale in demo

### DIFF
--- a/vaadin-time-picker-flow-demo/src/main/java/com/vaadin/flow/component/timepicker/demo/TimePickerView.java
+++ b/vaadin-time-picker-flow-demo/src/main/java/com/vaadin/flow/component/timepicker/demo/TimePickerView.java
@@ -66,6 +66,7 @@ public class TimePickerView extends DemoView {
         localesCB.setItemLabelGenerator(Locale::getDisplayName);
         localesCB.setWidth("300px");
         localesCB.setItems(availableLocales);
+        localesCB.setAllowCustomValue(false);
 
         TimePicker timePicker = new TimePicker();
 


### PR DESCRIPTION
It should resolve this issue:

Unhandled *NullPointerException* on page https://vaadin.com/components/vaadin-time-picker/java-examples
```Locale must not be null.```
> ...
> com.vaadin.flow.component.timepicker.demo.TimePickerView.lambda$createLocalizedTimePicker$ea26d33e$1(TimePickerView.java:69)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/45)
<!-- Reviewable:end -->
