### PR TITLE
Fix localization tests (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ driver
 
 # IntelliJ IDEA files
 .idea/
-vaadin-time-picker-flow.iml
+*.iml
 

--- a/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
+++ b/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerLocalizationIT.java
@@ -366,8 +366,7 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     }
 
     private String verifyFormat() {
-        String timePickerInputValue = getTimePickerElement()
-                .getTimePickerTextFieldValue();
+        String timePickerInputValue = getTimePickerTextFieldValueWithNormalSpaces();
         String formattedTextValue = getLabelValue();
         if (formattedTextValue.equals(timePickerInputValue)) {
             return null;
@@ -378,8 +377,7 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     }
 
     private String verifyFormatIncludingMilliseconds(String amPmString) {
-        String timePickerInputValue = getTimePickerElement()
-                .getTimePickerTextFieldValue();
+        String timePickerInputValue = getTimePickerTextFieldValueWithNormalSpaces();
         String[] splitInputValue = timePickerInputValue.replace(amPmString, "")
                 .split("\\.");
         String millisecondsInputValue = amPmString != null
@@ -439,5 +437,18 @@ public class TimePickerLocalizationIT extends AbstractComponentIT {
     private static String prettyPrint(Locale locale) {
         return locale.getDisplayName() + "["
                 + TimePickerLocalizationView.getLocaleString(locale) + "]";
+    }
+
+    /**
+     * Calls {@code getTimePickerTextFieldValue()} for {@code
+     * TimePickerElement} and replaces non-breaking space characters (char 160)
+     * with normal spaces (char 32) for easier comparison. Small number of
+     * locales (such as es-PA) seem to use those for their localized
+     * timestamps.
+     *
+     * @return space-normalized timestamp
+     */
+    private String getTimePickerTextFieldValueWithNormalSpaces() {
+        return getTimePickerElement().getTimePickerTextFieldValue().replace((char)160, (char)32);
     }
 }


### PR DESCRIPTION
Apparently some locales now use non-breaking space in their localizations -
those are now converted to normal spaces in the test comparisons

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/53)
<!-- Reviewable:end -->
