### PR TITLE
bug #22 TimePicker in Grid causes TypeError

### DIFF
--- a/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerInitializationView.java
+++ b/vaadin-time-picker-flow-integration-tests/src/main/java/com/vaadin/flow/component/timepicker/tests/TimePickerInitializationView.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2019 HealthPivots, all rights reserved
+ *
+ * @Created: Oct 15, 2019
+ */
+package com.vaadin.flow.component.timepicker.tests;
+
+import java.time.LocalTime;
+import java.util.Locale;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.component.timepicker.demo.TimePickerView;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+
+/**
+ * TimePickerIntializationView
+ */
+@Route("time-picker-initialization")
+public class TimePickerInitializationView extends Div implements HasUrlParameter<String> {
+
+	/**
+	 * Instantiates a new time picker initialization view.
+	 */
+	public TimePickerInitializationView() {
+		initTime(Locale.US, LocalTime.of(13, 42));
+	}
+
+	private void initTime(Locale locale, LocalTime time) {
+		// this must be first to test initialization
+		UI.getCurrent().setLocale(locale);
+
+		removeAll();
+		
+		final TimePicker timePicker = new TimePicker();
+		timePicker.setLabel(locale.getLanguage().concat("-").concat(locale.getCountry()));
+		
+		final TimePickerView.LocalTimeTextBlock browserFormattedTime = new TimePickerView.LocalTimeTextBlock();
+        browserFormattedTime.setId("formatted-time");
+        browserFormattedTime.setStep(timePicker.getStep());
+        browserFormattedTime.setLocale(locale);
+        
+        // set listener before setting time
+        timePicker.addValueChangeListener(event -> browserFormattedTime.setLocalTime(event.getValue()));
+        timePicker.setValue(time);
+        
+        add(timePicker, browserFormattedTime);
+	}
+	
+    @Override
+    public void setParameter(BeforeEvent beforeEvent,
+            @OptionalParameter String initialValue) {
+        if (initialValue != null) {
+            // eg. fi-FI-10-30
+            String[] split = initialValue.split("\\W");
+            Locale locale = new Locale(split[0], split[1]);
+
+            initTime(locale, LocalTime.of(Integer.parseInt(split[2]),
+                    Integer.parseInt(split[3])));
+        }
+    }
+}

--- a/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerInitializationIT.java
+++ b/vaadin-time-picker-flow-integration-tests/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerInitializationIT.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2019 HealthPivots, all rights reserved
+ *
+ * @Created: Oct 15, 2019
+ */
+package com.vaadin.flow.component.timepicker.tests;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+
+import com.vaadin.flow.component.timepicker.testbench.TimePickerElement;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
+
+@TestPath("time-picker-initialization")
+public class TimePickerInitializationIT extends AbstractComponentIT {
+
+    /** 
+     * Maximum is `Locale.getAvailableLocales()` about 159 that makes the
+     * test to take several minutes, testing a few of them also guarantees
+     * that the component is working correctly.
+     */
+    public static final int MINIMUM_NUMBER_OF_LOCALES_TO_TEST = 4;
+
+    @Before
+    public void init() {
+        open();
+        $(TimePickerElement.class).waitForFirst();
+    }
+
+    @Override
+    protected int getDeploymentPort() {
+        return super.getDeploymentPort();
+    }
+
+    @Test
+    public void testInitialValue_nonDefaultLocale_initialValueLocalizedCorrectly() {
+        runInitialLoadValueTestPattern("en-US", "15:00");
+        runInitialLoadValueTestPattern("en-CA", "03:00");
+        runInitialLoadValueTestPattern("fi-FI", "15:00");
+        runInitialLoadValueTestPattern("no-NO", "00:00");
+        runInitialLoadValueTestPattern("ar-SY", "15:00");
+        runInitialLoadValueTestPattern("ar-JO", "11:00");
+        runInitialLoadValueTestPattern("zh-TW", "15:00");
+        runInitialLoadValueTestPattern("ko-KR", "23:00");
+        runInitialLoadValueTestPattern("es-PA", "15:00");
+    }
+
+    private void runInitialLoadValueTestPattern(String locale, String time) {
+        String url = getTestURL() + "/" + locale + "-" + time;
+        this.getDriver().get(url);
+        waitForElementPresent(By.tagName("vaadin-time-picker"));
+
+        String error = verifyValueProperty(time);
+        Assert.assertNull(
+                "Wrong value on page load for locale " + locale + ": " + error,
+                error);
+        error = verifyFormat();
+        Assert.assertNull(
+                "Wrong format on page load for locale " + locale + ": " + error,
+                error);
+
+    }
+
+    private String verifyFormat() {
+        String timePickerInputValue = getTimePickerTextFieldValueWithNormalSpaces();
+        String formattedTextValue = getLabelValue();
+        if (formattedTextValue.equals(timePickerInputValue)) {
+            return null;
+        } else {
+            return "expected: " + formattedTextValue + " actual: "
+                    + timePickerInputValue;
+        }
+    }
+
+    private String getLabelValue() {
+        return $("div").id("formatted-time").getText();
+    }
+
+    /**
+     * Calls {@code getTimePickerTextFieldValue()} for {@code
+     * TimePickerElement} and replaces non-breaking space characters (char 160)
+     * with normal spaces (char 32) for easier comparison. Small number of
+     * locales (such as es-PA) seem to use those for their localized
+     * timestamps.
+     *
+     * @return space-normalized timestamp
+     */
+    private String getTimePickerTextFieldValueWithNormalSpaces() {
+        return getTimePickerElement().getTimePickerTextFieldValue().replace((char)160, (char)32);
+    }
+
+    private String verifyValueProperty(String value) {
+        String timePickerValue = getTimePickerElement().getValue();
+        if (value.equals(timePickerValue)) {
+            return null;
+        } else {
+            return "expected: " + value + " actual: " + timePickerValue;
+        }
+    }
+
+    private TimePickerElement getTimePickerElement() {
+        try {
+        	return $(TimePickerElement.class).waitForFirst();
+        } catch (NoSuchElementException e) {
+        	Assert.fail("TimePicker failed to initialize properly, no TimePicker found.");
+        	return null;
+        }
+    }
+}

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -371,12 +371,11 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         if (!locale.getCountry().isEmpty()) {
             bcp47LanguageTag.append("-").append(locale.getCountry());
         }
-        runBeforeClientResponse(ui -> getElement().callJsFunction(
-                "$connector.setLocale", bcp47LanguageTag.toString()));
         runBeforeClientResponse(ui -> {
-                PendingJavaScriptResult asyncResult = ui.getPage().executeJs(
-                    "void(0)", bcp47LanguageTag.toString());
-                asyncResult.then(x -> getElement().callJsFunction(
+                PendingJavaScriptResult asyncResult = getElement().callJsFunction(
+                        "$connector.setLocale", bcp47LanguageTag.toString());
+                asyncResult.then(x -> x.hashCode() /* do nothing on success (but needs a statement to compile */,
+                		err -> getElement().callJsFunction(
                     "$connector.setLocale", bcp47LanguageTag.toString()));
         });
 

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
@@ -316,10 +317,10 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
+        initConnector();
         if (getLocale() == null) {
             setLocale(attachEvent.getUI().getLocale());
         }
-        initConnector();
     }
 
     private void initConnector() {
@@ -375,6 +376,13 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         }
         runBeforeClientResponse(ui -> getElement().callFunction(
                 "$connector.setLocale", bcp47LanguageTag.toString()));
+        runBeforeClientResponse(ui -> {
+                PendingJavaScriptResult asyncResult = ui.getPage().executeJs(
+                    "void(0)", bcp47LanguageTag.toString());
+                asyncResult.then(x -> getElement().callJsFunction(
+                    "$connector.setLocale", bcp47LanguageTag.toString()));
+        });
+
     }
 
     /**

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -37,6 +37,8 @@ import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.shared.Registration;
 
+import elemental.json.JsonValue;
+
 /**
  * An input component for selecting time of day, based on
  * {@code vaadin-time-picker} web component.
@@ -374,7 +376,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         runBeforeClientResponse(ui -> {
                 PendingJavaScriptResult asyncResult = getElement().callJsFunction(
                         "$connector.setLocale", bcp47LanguageTag.toString());
-                asyncResult.then(x -> x.hashCode() /* do nothing on success (but needs a statement to compile */,
+                asyncResult.then(JsonValue::hashCode /* do nothing on success (but needs a statement to compile */,
                 		err -> getElement().callJsFunction(
                     "$connector.setLocale", bcp47LanguageTag.toString()));
         });

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -48,14 +48,11 @@ import com.vaadin.flow.shared.Registration;
 public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         implements HasSize, HasValidation, HasEnabled {
 
-    private static final SerializableFunction<String, LocalTime> PARSER = valueFromClient -> {
-        return valueFromClient == null || valueFromClient.isEmpty() ? null
-                : LocalTime.parse(valueFromClient);
-    };
+    private static final SerializableFunction<String, LocalTime> PARSER = valueFromClient -> 
+        valueFromClient == null || valueFromClient.isEmpty() ? null: LocalTime.parse(valueFromClient);
 
-    private static final SerializableFunction<LocalTime, String> FORMATTER = valueFromModel -> {
-        return valueFromModel == null ? "" : valueFromModel.toString();
-    };
+    private static final SerializableFunction<LocalTime, String> FORMATTER = valueFromModel -> 
+        valueFromModel == null ? "" : valueFromModel.toString();
 
     private static final long MILLISECONDS_IN_A_DAY = 86400000L;
     private static final long MILLISECONDS_IN_AN_HOUR = 3600000L;
@@ -63,8 +60,8 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     private Locale locale;
     private transient DateTimeFormatter dateTimeFormatter;
 
-    private LocalTime max;
-    private LocalTime min;
+    private transient LocalTime max;
+    private transient LocalTime min;
     private boolean required;
 
 
@@ -326,7 +323,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
     private void initConnector() {
         // can't run this with getElement().executeJavaScript(...) since then
         // setLocale might be called before this causing client side error
-        runBeforeClientResponse(ui -> ui.getPage().executeJavaScript(
+        runBeforeClientResponse(ui -> ui.getPage().executeJs(
                 "window.Vaadin.Flow.timepickerConnector.initLazy($0)",
                 getElement()));
     }
@@ -374,7 +371,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
         if (!locale.getCountry().isEmpty()) {
             bcp47LanguageTag.append("-").append(locale.getCountry());
         }
-        runBeforeClientResponse(ui -> getElement().callFunction(
+        runBeforeClientResponse(ui -> getElement().callJsFunction(
                 "$connector.setLocale", bcp47LanguageTag.toString()));
         runBeforeClientResponse(ui -> {
                 PendingJavaScriptResult asyncResult = ui.getPage().executeJs(


### PR DESCRIPTION
the problem is the FIXME lines in timepickerConnector.js
 - they access the shadow DOM, but it hasn't been inititalized
   when setting the locale upon initial attachment.

This solution just makes a dumy JS void(0) call, and upon success,
asynchronously calls setLocale().  This allows the client to fully
initialize the element and nodes before attempting to directly acccess
them in an unsafe manner.

I'm sure there is a better way, thus the "FIXME" comment in there, but
as this is my first foray into Vaadin 10+, I'll stick to the server side.

This can be verified as correct by setting the locale before the sample code in the issue:

UI.getCurrent().setLocale(Locale.CHINA);

and observing that the time is displayed with the proper format upon first render in the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-time-picker-flow/56)
<!-- Reviewable:end -->
