### PR TITLE
Fix setMin/setMax when called with null

### DIFF
--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/TimePicker.java
@@ -406,7 +406,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      */
     @Override
     public void setMin(String min) {
-        this.min = LocalTime.parse(min, initializeAndReturnFormatter());
+        this.min = min != null ? LocalTime.parse(min, initializeAndReturnFormatter()) : null;
         super.setMin(min);
     }
 
@@ -431,7 +431,7 @@ public class TimePicker extends GeneratedVaadinTimePicker<TimePicker, LocalTime>
      */
     @Override
     public void setMax(String max) {
-        this.max = LocalTime.parse(max, initializeAndReturnFormatter());
+        this.max = max != null ? LocalTime.parse(max, initializeAndReturnFormatter()) : null;
         super.setMax(max);
     }
 

--- a/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
+++ b/vaadin-time-picker-flow/src/test/java/com/vaadin/flow/component/timepicker/tests/TimePickerTest.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.timepicker.tests;
 import java.time.Duration;
 import java.time.LocalTime;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.timepicker.TimePicker;
@@ -159,10 +158,26 @@ public class TimePickerTest {
     }
 
     @Test
+    public void setMin_getMin_null() {
+        TimePicker timePicker = new TimePicker();
+        assertEquals(null, timePicker.getMin());
+        timePicker.setMin(null);
+        assertEquals("", timePicker.getMin());
+    }
+
+    @Test
     public void setMax_getMax() {
         TimePicker timePicker = new TimePicker();
         timePicker.setMax("12:00");
         assertEquals("12:00", timePicker.getMax());
+    }
+
+    @Test
+    public void setMax_getMax_null() {
+        TimePicker timePicker = new TimePicker();
+        assertEquals(null, timePicker.getMax());
+        timePicker.setMax(null);
+        assertEquals("", timePicker.getMax());
     }
 
     @Test


### PR DESCRIPTION
Check for null on the argument before passing it to `LocalTime#parse`.
Add tests for this case.

Fixes #61