### PR TITLE
Fix connector tryCatchWrapper definition

### DIFF
--- a/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
+++ b/vaadin-time-picker-flow/src/main/resources/META-INF/resources/frontend/timepickerConnector.js
@@ -1,6 +1,8 @@
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker', 'vaadin-time-picker-flow');
+        return (...args) => {
+            return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Time Picker', 'vaadin-time-picker-flow')(...args);
+        };
     };
 
     window.Vaadin.Flow.timepickerConnector = {


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-combo-box-flow/issues/313
Make the `Flow.tryCatchWrapper` called lazily.