### PR TITLE
Use correct snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-component-base</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-time-picker-flow-parent</artifactId>


### PR DESCRIPTION
FCB and Flow 2.2 has been used for releases as VTP 2.1 targets 14.2