### PR TITLE
Bump web component version to 2.2.1

### DIFF
--- a/vaadin-time-picker-flow/pom.xml
+++ b/vaadin-time-picker-flow/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-time-picker</artifactId>
-            <version>2.2.0</version>
+            <version>2.2.1</version>
         </dependency>
 
         <dependency>

--- a/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
+++ b/vaadin-time-picker-flow/src/main/java/com/vaadin/flow/component/timepicker/GeneratedVaadinTimePicker.java
@@ -130,7 +130,7 @@ import elemental.json.JsonObject;
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#2.0-SNAPSHOT",
         "WebComponent: Vaadin.TimePickerElement#2.0.0", "Flow#2.0-SNAPSHOT" })
 @Tag("vaadin-time-picker")
-@NpmPackage(value = "@vaadin/vaadin-time-picker", version = "2.2.0")
+@NpmPackage(value = "@vaadin/vaadin-time-picker", version = "2.2.1")
 @JsModule("@vaadin/vaadin-time-picker/src/vaadin-time-picker.js")
 @HtmlImport("frontend://bower_components/vaadin-time-picker/src/vaadin-time-picker.html")
 public abstract class GeneratedVaadinTimePicker<R extends GeneratedVaadinTimePicker<R, T>, T>


### PR DESCRIPTION
This version only contains a demo fix, so no need to cherry-pick for V16.